### PR TITLE
Add lint error to ibex.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/google/verible
 [submodule "ibex"]
 	path = ibex
-	url = https://github.com/lowRISC/ibex
+	url = https://github.com/antmicro/ibex


### PR DESCRIPTION
Example run of fusesoc verible_lint on source with lint error.